### PR TITLE
Do not archive confirmation tweet of bot

### DIFF
--- a/twitterbot.js
+++ b/twitterbot.js
@@ -57,6 +57,9 @@ async function getTweetContent(status, replyTweet, requestor, twToTwtch) {
 		response
 	) {
 		if (response.statusCode === 200) {
+			if (data.full_text.includes("I twetched it for you")){
+				return;
+			}
 			let txid;
 			let twObj = {
 				created_at: data.created_at,


### PR DESCRIPTION
Do not archive the reply confirmation tweet. Automatically return if the replied to tweet contains "I twetched it for you"