### PR TITLE
Fix duplicate twetchdat request reply on Twitter

### DIFF
--- a/twitterbot.js
+++ b/twitterbot.js
@@ -195,7 +195,7 @@ This post is now forever on the blockchain
 Link to post 👇
 ${twetchURL}`;
 	if (rt){
-		twtContent = rt;
+		twtContent = `@${requestor} ${rt}`;
 	}
 
 	return new Promise((resolve, reject) => {


### PR DESCRIPTION
Fix error if a duplicate twetchdat request was made against a Tweet.

Add a mention to the retweet of the original reply to twetchdat so that the retweet is a reply instead of just a retweet.